### PR TITLE
Handle small sample size in performance health

### DIFF
--- a/server/services/performance-monitor.ts
+++ b/server/services/performance-monitor.ts
@@ -707,7 +707,12 @@ export class PerformanceMonitor {
     // Check various health indicators
     if (summary.errorRate > 10) {
       issues.push(`High error rate: ${summary.errorRate.toFixed(1)}%`);
-      status = 'unhealthy';
+      if (summary.totalRequests >= 10) {
+        status = 'unhealthy';
+      } else if (status === 'healthy') {
+        // With a very small sample size, treat the high error rate as degraded
+        status = 'degraded';
+      }
     } else if (summary.errorRate > 5) {
       issues.push(`Elevated error rate: ${summary.errorRate.toFixed(1)}%`);
       if (status === 'healthy') status = 'degraded';


### PR DESCRIPTION
## Summary
- avoid marking the app as unhealthy when high error rate occurs with very few requests
- document small sample handling in performance monitor health checks

## Testing
- `npx vitest run --dir tests services/performance-monitor.test.ts`
- `npm run check` *(fails: client/src/components/momentum-analysis.tsx(506,1): error TS1128: Declaration or statement expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a026c9c83328338a5f11a56eb68